### PR TITLE
fixed   can't find FontResource.Path

### DIFF
--- a/quick/framework/cc/uiloader/CCSUILoader2.lua
+++ b/quick/framework/cc/uiloader/CCSUILoader2.lua
@@ -416,7 +416,7 @@ function CCSUILoader:createButton(options)
 		node:setButtonLabel(
 			cc.ui.UILabel.new({text = options.ButtonText,
 				size = options.FontSize,
-				font = options.fontName,
+				font = options.FontResource and options.FontResource.Path,
 				color = cc.c3b(options.TextColor.R, options.TextColor.G, options.TextColor.B)}))
 	end
 	if options.Size then


### PR DESCRIPTION
修正，在解析 ccs2 的时候 button 按钮上的text时候不正正确解析 font 参数 。